### PR TITLE
Pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,17 +44,17 @@ dependencies = [
     "numpy==1.26.4",
     "pyserial==3.5",
     "scipy==1.14.0",
-    "opencv-python==4.10.0.84",
+    #"opencv-python==4.10.0.84",
     "pyyaml==6.0.1",
-    "onnxruntime==1.18.1",
+    #"onnxruntime==1.18.1",
     "matplotlib==3.9.1",
     "fastapi>=0.109.1,<0.110.0", # https://github.com/zauberzeug/nicegui/security/dependabot/27
     "nicegui==1.4.26",
     "nicegui-highcharts==1.0.1",
-    "torch==2.3.1",
+    #"torch==2.3.1",
     "flask==3.0.3",
     "pydbus==0.6.0",
-    "torchvision==0.18.1"
+    #"torchvision==0.18.1"
 ]
 
 [tool.hatch.envs.dev]


### PR DESCRIPTION
Use hatch env to manage dependencies between different dev environments:

https://hatch.pypa.io/1.12/environment/

use https://hatch.pypa.io/1.12/cli/reference/#hatch-env-show to show existing env setup in the pyproject.toml file. You can use each environment similar to how vitual-env works, but with hatch syntax.