### PR TITLE
pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,17 +44,17 @@ dependencies = [
     "numpy==1.26.4",
     "pyserial==3.5",
     "scipy==1.14.0",
-    "opencv-python==4.10.0.84",
+    #"opencv-python==4.10.0.84",
     "pyyaml==6.0.1",
-    "onnxruntime==1.18.1",
+    #"onnxruntime==1.18.1",
     "matplotlib==3.9.1",
     "fastapi>=0.109.1,<0.110.0", # https://github.com/zauberzeug/nicegui/security/dependabot/27
     "nicegui==1.4.26",
     "nicegui-highcharts==1.0.1",
-    "torch==2.3.1",
+    #"torch==2.3.1",
     "flask==3.0.3",
     "pydbus==0.6.0",
-    "torchvision==0.18.1"
+    #"torchvision==0.18.1"
 ]
 
 [tool.hatch.envs.dev]


### PR DESCRIPTION
- **Removing tag-pattern from vcs as caused issue with tag v0.0.1**
  

- **Reverting removal of dependency versions**
  

- **Initial skeleton for hatch envs. Also updated requires python >=3.8,<3.11 else wouldn't install locally**
  

- **Updating nicegui-highcharts to 1.4.26**
  

- **typo in default**
  

- **resolving fastapi + nicegui version conflict**
  

- **Commenting out jetson jetpack packages until can find another solution for managing them other than hatch/pyproject.toml**
  