### PR TITLE
Extended range of valid initalization paths, e.g. ../models/modelN+…[optional /best.onnx or xxx.tflite etc)

### DIFF
--- a/src/beachbot/ai/debrisdetector.py
+++ b/src/beachbot/ai/debrisdetector.py
@@ -26,7 +26,10 @@ class DerbrisDetector():
 
 
         if model_file is not None:
-            model_folder = os.path.dirname(os.path.realpath(model_file))
+            if "." in model_file:
+                model_folder = os.path.dirname(os.path.realpath(model_file))
+            else:
+                model_folder = os.path.realpath(model_file)
             with open(model_folder + "/export_info.yaml", 'r') as stream:
                 export_info = yaml.safe_load(stream)
                 self.img_height = export_info['img_heigt_export']

--- a/src/beachbot/ai/yolov5_onnx.py
+++ b/src/beachbot/ai/yolov5_onnx.py
@@ -21,6 +21,8 @@ class Yolo5Onnx(DerbrisDetector):
         else:
             logger.info("No Gpu acceleration availabe!")
         logger.info("DL providers are:" + str(providers))
+        if not model_file.endswith(".onnx"):
+            model_file += "/best.onnx"
         self.session = onnxruntime.InferenceSession(model_file, providers=providers)
         if self.session is None:
             raise ValueError("Failed to load the model " + model_file)

--- a/src/beachbot/ai/yolov5_torch_hub.py
+++ b/src/beachbot/ai/yolov5_torch_hub.py
@@ -15,7 +15,10 @@ class Yolo5TorchHub(DerbrisDetector):
 
     def __init__(self, model_file, use_accel=True) -> None:
         super().__init__(None)
-        model_folder = os.path.dirname(os.path.realpath(model_file))
+        if "." in model_file:
+            model_folder = os.path.dirname(os.path.realpath(model_file))
+        else:
+            model_folder = os.path.realpath(model_file)
         model_type=None
         with open(model_folder + "/export_info.yaml", 'r') as stream:
             export_info = yaml.safe_load(stream)


### PR DESCRIPTION
Listing of folder may does not include the model file best.onnx or model.tflite.
To be more general, I modified the model classes in such way that they accept just the folder path ...models/modelX [optional / at the end]. if there is no "." in the last path element, it is considered to be a folder name and not a file name!
E.g. 
Previous  behavior: load from "/models/modelfolder1" -> modelfolder1 considered to be file name, model loaded from /models -> fail!
Now:
load from "/models/modelfolder1" -> modelfolder1 ha no ".", thus considered to be folder name, model loaded from /models/modelfolder1/ -> OK!
