### PR TITLE
Revert "mirrored dependencies in pyproject.toml for pip install compatibility"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,22 +19,6 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
 ]
 license = { text = "TBD" }
-dependencies = [
-    "numpy>=1.26.4",
-    "pyserial>=3.5",
-    "scipy>=1.14.0",
-    "opencv-python>=4.10.0.84",
-    "pyyaml>=6.0.1",
-    "onnxruntime>=1.18.1",
-    "matplotlib>=3.9.1",
-    "fastapi>=0.109.1,<0.110.0", # https://github.com/zauberzeug/nicegui/security/dependabot/27
-    "nicegui>=1.4.26",
-    "nicegui-highcharts>=1.0.1",
-    "torch>=2.3.1",
-    "flask>=3.0.3",
-    "pydbus>=0.6.0",
-    "torchvision>=0.18.1",
-]
 
 # default = release
 [tool.hatch.envs.default]


### PR DESCRIPTION
This reverts commit 1ddb411e64fb4eaef499aecd398d3d8381ce6340.
